### PR TITLE
Refactor (src/user/picture.js): Function with high complexity (count = 21): exports

### DIFF
--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -12,56 +12,17 @@ const meta = require('../meta');
 
 module.exports = function (User) {
 
-	User.getAllowedProfileImageExtensions = function () {
-		const exts = User.getAllowedImageTypes().map(type => mime.getExtension(type));
-		if (exts.includes('jpeg')) {
-			exts.push('jpg');
-		}
-		return exts;
-	};
+	User.getAllowedProfileImageExtensions = () => getAllowedProfileImageExtensionsWrapper(User);
 
-	User.getAllowedImageTypes = function () {
-		return ['image/png', 'image/jpeg', 'image/bmp', 'image/gif'];
-	};
+	User.getAllowedImageTypes = () => getAllowedImageTypesWrapper(User);
 
 	User.updateCoverPosition = (uid, position) => updateCoverPositionWrapper(User, uid, position);
 
-	User.updateCoverPicture = async function (data) {
-		const picture = {
-			name: 'profileCover',
-			uid: data.uid,
-		};
-
-		try {
-			if (!data.imageData && data.position) {
-				return await User.updateCoverPosition(data.uid, data.position);
-			}
-
-			validateUpload(data, meta.config.maximumCoverImageSize, ['image/png', 'image/jpeg', 'image/bmp']);
-
-			picture.path = await image.writeImageDataToTempFile(data.imageData);
-
-			const extension = file.typeToExtension(image.mimeFromBase64(data.imageData));
-			const filename = `${data.uid}-profilecover-${Date.now()}${extension}`;
-			const uploadData = await image.uploadImage(filename, `profile/uid-${data.uid}`, picture);
-
-			await deleteCurrentPicture(User, data.uid, 'cover:url');
-			await User.setUserField(data.uid, 'cover:url', uploadData.url);
-
-			if (data.position) {
-				await User.updateCoverPosition(data.uid, data.position);
-			}
-
-			return {
-				url: uploadData.url,
-			};
-		} finally {
-			await file.delete(picture.path);
-		}
-	};
+	User.updateCoverPicture = data => updateCoverPictureWrapper(User, data);
 
 	// uploads a image file as profile picture
 	User.uploadCroppedPictureFile = async function (data) {
+		
 		const userPhoto = data.file;
 		if (!meta.config.allowProfileImageUploads) {
 			throw new Error('[[error:profile-image-uploads-disabled]]');
@@ -126,6 +87,7 @@ module.exports = function (User) {
 	};
 
 	User.removeProfileImage = async function (uid) {
+		
 		const userData = await User.getUserFields(uid, ['uploadedpicture', 'picture']);
 		await deletePicture(User, uid, 'uploadedpicture');
 		await User.setUserFields(uid, {
@@ -155,8 +117,22 @@ module.exports = function (User) {
 	
 };
 
+// Wrapper to get allowed image types
+function getAllowedImageTypesWrapper() {
+	return ['image/png', 'image/jpeg', 'image/bmp', 'image/gif'];
+};
+
+// Wrapper to get allowed profile image extensions
+function getAllowedProfileImageExtensionsWrapper(User) {
+	
+	const exts = getAllowedImageTypesWrapper(User).map(type => mime.getExtension(type));
+	if (exts.includes('jpeg')) exts.push('jpg');
+	return exts;
+};
+
 // Wrapper for updating cover position
 function updateCoverPositionWrapper(User, uid, position) {
+	
 	if (!/^[\d.]+%\s[\d.]+%$/.test(position)) {
 		winston.warn(`[user/updateCoverPosition] Invalid position received: ${position}`);
 		throw new Error('[[error:invalid-data]]');
@@ -164,8 +140,42 @@ function updateCoverPositionWrapper(User, uid, position) {
 	return User.setUserField(uid, 'cover:position', position);
 };
 
+// Wrapper for updating cover picture
+async function updateCoverPictureWrapper(User, data) {
+	const picture = { name: 'profileCover', uid: data.uid };
+	
+
+	try {
+		if (!data.imageData && data.position) {
+			return await updateCoverPositionWrapper(User, data.uid, data.position);
+		}
+
+		validateUpload(data, meta.config.maximumCoverImageSize, ['image/png', 'image/jpeg', 'image/bmp']);
+
+		picture.path = await image.writeImageDataToTempFile(data.imageData);
+
+		const extension = file.typeToExtension(image.mimeFromBase64(data.imageData));
+		const filename = `${data.uid}-profilecover-${Date.now()}${extension}`;
+		const uploadData = await image.uploadImage(filename, `profile/uid-${data.uid}`, picture);
+
+		await deleteCurrentPicture(User, data.uid, 'cover:url');
+		await User.setUserField(data.uid, 'cover:url', uploadData.url);
+
+		if (data.position) {
+			await updateCoverPositionWrapper(User, data.uid, data.position);
+		}
+
+		return { url: uploadData.url };
+	} 
+	finally 
+	{
+		await file.delete(picture.path);
+	}
+}
+
 // Wrapper function which encapsulates the upload validation logic
 function validateUploadWrapper(User, data) {
+	
 	if (!meta.config.allowProfileImageUploads) {
 		throw new Error('[[error:profile-image-uploads-disabled]]');
 	}
@@ -177,8 +187,10 @@ function validateUploadWrapper(User, data) {
 	}
 	return extension;
 };
+
 // Wrapper function which encapsulates getting a photo path
 async function getProfilePathWrapper(imageData) {
+	
 	let tempPath = await image.writeImageDataToTempFile(imageData);
 	tempPath = await convertToPNG(tempPath);
 	return tempPath;
@@ -186,6 +198,7 @@ async function getProfilePathWrapper(imageData) {
 
 // Wrapper function which uploads photo path
 async function uploadProfilePathWrapper(uid, tempPath, extension) {
+	
 	const filename = generateProfileImageFilename(uid, extension);
 	return await image.uploadImage(filename, `profile/uid-${uid}`, {
 		uid,

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -113,26 +113,14 @@ module.exports = function (User) {
 
 	// uploads image data in base64 as profile picture
 	User.uploadCroppedPicture = async function (data) {
-		const picture = {
-			name: 'profileAvatar',
-			uid: data.uid,
-		};
-
 		try {
 			
 			const extension = validateUploadWrapper(data);
 			const tempPath = await getProfilePathWrapper(data.imageData);
-
-			await image.resizeImage({
-				path: picture.path,
-				width: meta.config.profileImageDimension,
-				height: meta.config.profileImageDimension,
-			});
-
-			const uploadedImage = generateProfileImageFilename(data.uid, extension);
-
+			const uploadedImage = uploadProfilePathWrapper(data.uid, tempPath, extension);
 			await updateProfilePathWrapper(data.callerUid, data.uid, uploadedImage.url);
 			return uploadedImage;
+
 		} finally {
 			await file.delete(tempPath);
 		}
@@ -159,7 +147,17 @@ module.exports = function (User) {
 		return tempPath;
 	}
 
-	// Wrapper function which updates path
+	// Wrapper function which uploads photo path
+	async function uploadProfilePathWrapper(uid, tempPath, extension) {
+		const filename = generateProfileImageFilename(uid, extension);
+		return await image.uploadImage(filename, `profile/uid-${uid}`, {
+			uid,
+			path: tempPath,
+			name: 'profileAvatar',
+		});
+	}
+
+	// Wrapper function which updates photo path
 	async function updateProfilePathWrapper(callerUid, uid, imageUrl) {
 		await deleteCurrentPicture(uid, 'uploadedpicture');
 		await User.updateProfile(callerUid, {

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -121,11 +121,7 @@ module.exports = function (User) {
 		try {
 			
 			const extension = validateUploadWrapper(data);
-			const tempPath = await getProfilePath(data.imageData);
-			
-
-			picture.path = await image.writeImageDataToTempFile(data.imageData);
-			picture.path = await convertToPNG(picture.path);
+			const tempPath = await getProfilePathWrapper(data.imageData);
 
 			await image.resizeImage({
 				path: picture.path,
@@ -133,18 +129,12 @@ module.exports = function (User) {
 				height: meta.config.profileImageDimension,
 			});
 
-			const filename = generateProfileImageFilename(data.uid, extension);
-			const uploadedImage = await image.uploadImage(filename, `profile/uid-${data.uid}`, picture);
+			const uploadedImage = generateProfileImageFilename(data.uid, extension);
 
-			await deleteCurrentPicture(data.uid, 'uploadedpicture');
-			await User.updateProfile(data.callerUid, {
-				uid: data.uid,
-				uploadedpicture: uploadedImage.url,
-				picture: uploadedImage.url,
-			}, ['uploadedpicture', 'picture']);
+			await updateProfilePathWrapper(data.callerUid, data.uid, uploadedImage.url);
 			return uploadedImage;
 		} finally {
-			await file.delete(picture.path);
+			await file.delete(tempPath);
 		}
 	};
 
@@ -163,10 +153,20 @@ module.exports = function (User) {
 	};
 
 	// Wrapper function which encapsulates getting a photo path
-	async function getProfilePath(imageData) {
+	async function getProfilePathWrapper(imageData) {
 		let tempPath = await image.writeImageDataToTempFile(imageData);
 		tempPath = await convertToPNG(tempPath);
 		return tempPath;
+	}
+
+	// Wrapper function which updates path
+	async function updateProfilePathWrapper(callerUid, uid, imageUrl) {
+		await deleteCurrentPicture(uid, 'uploadedpicture');
+		await User.updateProfile(callerUid, {
+			uid,
+			uploadedpicture: imageUrl,
+			picture: imageUrl,
+		}, ['uploadedpicture', 'picture']);
 	}
 
 	async function deleteCurrentPicture(uid, field) {

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -119,16 +119,10 @@ module.exports = function (User) {
 		};
 
 		try {
-			if (!meta.config.allowProfileImageUploads) {
-				throw new Error('[[error:profile-image-uploads-disabled]]');
-			}
-
-			validateUpload(data, meta.config.maximumProfileImageSize, User.getAllowedImageTypes());
-
-			const extension = file.typeToExtension(image.mimeFromBase64(data.imageData));
-			if (!extension) {
-				throw new Error('[[error:invalid-image-extension]]');
-			}
+			
+			const extension = validateUploadWrapper(data);
+			const tempPath = await getProfilePath(data.imageData);
+			
 
 			picture.path = await image.writeImageDataToTempFile(data.imageData);
 			picture.path = await convertToPNG(picture.path);
@@ -167,6 +161,13 @@ module.exports = function (User) {
 		}
 		return extension;
 	};
+
+	// Wrapper function which encapsulates getting a photo path
+	async function getProfilePath(imageData) {
+		let tempPath = await image.writeImageDataToTempFile(imageData);
+		tempPath = await convertToPNG(tempPath);
+		return tempPath;
+	}
 
 	async function deleteCurrentPicture(uid, field) {
 		if (meta.config['profile:keepAllUserImages']) {

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -154,6 +154,20 @@ module.exports = function (User) {
 		}
 	};
 
+	// Wrapper function which encapsulates the upload validation logic
+	function validateUploadWrapper(data) {
+		if (!meta.config.allowProfileImageUploads) {
+			throw new Error('[[error:profile-image-uploads-disabled]]');
+		}
+		validateUpload(data, meta.config.maximumProfileImageSize, User.getAllowedImageTypes());
+
+		const extension = file.typeToExtension(image.mimeFromBase64(data.imageData));
+		if (!extension) {
+			throw new Error('[[error:invalid-image-extension]]');
+		}
+		return extension;
+	};
+
 	async function deleteCurrentPicture(uid, field) {
 		if (meta.config['profile:keepAllUserImages']) {
 			return;
@@ -230,4 +244,6 @@ module.exports = function (User) {
 		const filename = value.split('/').pop();
 		return path.join(nconf.get('upload_path'), `profile/uid-${uid}`, filename);
 	}
+
+	
 };

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -11,6 +11,7 @@ const image = require('../image');
 const meta = require('../meta');
 
 module.exports = function (User) {
+
 	User.getAllowedProfileImageExtensions = function () {
 		const exts = User.getAllowedImageTypes().map(type => mime.getExtension(type));
 		if (exts.includes('jpeg')) {
@@ -52,7 +53,7 @@ module.exports = function (User) {
 			const filename = `${data.uid}-profilecover-${Date.now()}${extension}`;
 			const uploadData = await image.uploadImage(filename, `profile/uid-${data.uid}`, picture);
 
-			await deleteCurrentPicture(data.uid, 'cover:url');
+			await deleteCurrentPicture(User, data.uid, 'cover:url');
 			await User.setUserField(data.uid, 'cover:url', uploadData.url);
 
 			if (data.position) {
@@ -102,7 +103,7 @@ module.exports = function (User) {
 			name: 'profileAvatar',
 		});
 
-		await deleteCurrentPicture(data.uid, 'uploadedpicture');
+		await deleteCurrentPicture(User, data.uid, 'uploadedpicture');
 		await User.updateProfile(data.callerUid, {
 			uid: data.uid,
 			uploadedpicture: uploadedImage.url,
@@ -113,12 +114,12 @@ module.exports = function (User) {
 
 	// uploads image data in base64 as profile picture
 	User.uploadCroppedPicture = async function (data) {
-		const extension = validateUploadWrapper(data);
+		const extension = validateUploadWrapper(User, data);
 		const tempPath = await getProfilePathWrapper(data.imageData);
 
 		try {
 			
-			const uploadedImage = uploadProfilePathWrapper(data.uid, tempPath, extension);
+			const uploadedImage = await uploadProfilePathWrapper(data.uid, tempPath, extension);
 			await updateProfilePathWrapper(data.callerUid, data.uid, uploadedImage.url);
 			return uploadedImage;
 
@@ -127,99 +128,14 @@ module.exports = function (User) {
 		}
 	};
 
-	// Wrapper function which encapsulates the upload validation logic
-	function validateUploadWrapper(data) {
-		if (!meta.config.allowProfileImageUploads) {
-			throw new Error('[[error:profile-image-uploads-disabled]]');
-		}
-		validateUpload(data, meta.config.maximumProfileImageSize, User.getAllowedImageTypes());
-
-		const extension = file.typeToExtension(image.mimeFromBase64(data.imageData));
-		if (!extension) {
-			throw new Error('[[error:invalid-image-extension]]');
-		}
-		return extension;
-	};
-
-	// Wrapper function which encapsulates getting a photo path
-	async function getProfilePathWrapper(imageData) {
-		let tempPath = await image.writeImageDataToTempFile(imageData);
-		tempPath = await convertToPNG(tempPath);
-		return tempPath;
-	}
-
-	// Wrapper function which uploads photo path
-	async function uploadProfilePathWrapper(uid, tempPath, extension) {
-		const filename = generateProfileImageFilename(uid, extension);
-		return await image.uploadImage(filename, `profile/uid-${uid}`, {
-			uid,
-			path: tempPath,
-			name: 'profileAvatar',
-		});
-	}
-
-	// Wrapper function which updates photo path
-	async function updateProfilePathWrapper(callerUid, uid, imageUrl) {
-		await deleteCurrentPicture(uid, 'uploadedpicture');
-		await User.updateProfile(callerUid, {
-			uid,
-			uploadedpicture: imageUrl,
-			picture: imageUrl,
-		}, ['uploadedpicture', 'picture']);
-	}
-
-	async function deleteCurrentPicture(uid, field) {
-		if (meta.config['profile:keepAllUserImages']) {
-			return;
-		}
-		await deletePicture(uid, field);
-	}
-
-	async function deletePicture(uid, field) {
-		const uploadPath = await getPicturePath(uid, field);
-		if (uploadPath) {
-			await file.delete(uploadPath);
-		}
-	}
-
-	function validateUpload(data, maxSize, allowedTypes) {
-		if (!data.imageData) {
-			throw new Error('[[error:invalid-data]]');
-		}
-		const size = image.sizeFromBase64(data.imageData);
-		if (size > maxSize * 1024) {
-			throw new Error(`[[error:file-too-big, ${maxSize}]]`);
-		}
-
-		const type = image.mimeFromBase64(data.imageData);
-		if (!type || !allowedTypes.includes(type)) {
-			throw new Error('[[error:invalid-image]]');
-		}
-	}
-
-	async function convertToPNG(path) {
-		const convertToPNG = meta.config['profile:convertProfileImageToPNG'] === 1;
-		if (!convertToPNG) {
-			return path;
-		}
-		const newPath = await image.normalise(path);
-		await file.delete(path);
-		return newPath;
-	}
-
-	function generateProfileImageFilename(uid, extension) {
-		const convertToPNG = meta.config['profile:convertProfileImageToPNG'] === 1;
-		return `${uid}-profileavatar-${Date.now()}${convertToPNG ? '.png' : extension}`;
-	}
-
 	User.removeCoverPicture = async function (data) {
-		await deletePicture(data.uid, 'cover:url');
+		await deletePicture(User, data.uid, 'cover:url');
 		await db.deleteObjectFields(`user:${data.uid}`, ['cover:url', 'cover:position']);
 	};
 
 	User.removeProfileImage = async function (uid) {
 		const userData = await User.getUserFields(uid, ['uploadedpicture', 'picture']);
-		await deletePicture(uid, 'uploadedpicture');
+		await deletePicture(User, uid, 'uploadedpicture');
 		await User.setUserFields(uid, {
 			uploadedpicture: '',
 			// if current picture is uploaded picture, reset to user icon
@@ -229,21 +145,103 @@ module.exports = function (User) {
 	};
 
 	User.getLocalCoverPath = async function (uid) {
-		return getPicturePath(uid, 'cover:url');
+		return getPicturePath(User, uid, 'cover:url');
 	};
 
 	User.getLocalAvatarPath = async function (uid) {
-		return getPicturePath(uid, 'uploadedpicture');
+		return getPicturePath(User, uid, 'uploadedpicture');
 	};
 
-	async function getPicturePath(uid, field) {
-		const value = await User.getUserField(uid, field);
-		if (!value || !value.startsWith(`${nconf.get('relative_path')}/assets/uploads/profile/uid-${uid}`)) {
-			return false;
-		}
-		const filename = value.split('/').pop();
-		return path.join(nconf.get('upload_path'), `profile/uid-${uid}`, filename);
+	async function updateProfilePathWrapper(callerUid, uid, imageUrl) {
+		await deleteCurrentPicture(User, uid, 'uploadedpicture');
+		await User.updateProfile(callerUid, {
+			uid,
+			uploadedpicture: imageUrl,
+			picture: imageUrl,
+		}, ['uploadedpicture', 'picture']);
 	}
-
 	
 };
+
+// Wrapper function which encapsulates the upload validation logic
+function validateUploadWrapper(User, data) {
+	if (!meta.config.allowProfileImageUploads) {
+		throw new Error('[[error:profile-image-uploads-disabled]]');
+	}
+	validateUpload(data, meta.config.maximumProfileImageSize, User.getAllowedImageTypes());
+
+	const extension = file.typeToExtension(image.mimeFromBase64(data.imageData));
+	if (!extension) {
+		throw new Error('[[error:invalid-image-extension]]');
+	}
+	return extension;
+};
+// Wrapper function which encapsulates getting a photo path
+async function getProfilePathWrapper(imageData) {
+	let tempPath = await image.writeImageDataToTempFile(imageData);
+	tempPath = await convertToPNG(tempPath);
+	return tempPath;
+}
+
+// Wrapper function which uploads photo path
+async function uploadProfilePathWrapper(uid, tempPath, extension) {
+	const filename = generateProfileImageFilename(uid, extension);
+	return await image.uploadImage(filename, `profile/uid-${uid}`, {
+		uid,
+		path: tempPath,
+		name: 'profileAvatar',
+	});
+}
+
+async function deleteCurrentPicture(User, uid, field) {
+	if (meta.config['profile:keepAllUserImages']) {
+		return;
+	}
+	await deletePicture(User, uid, field);
+}
+
+async function deletePicture(User, uid, field) {
+	const uploadPath = await getPicturePath(User, uid, field);
+	if (uploadPath) {
+		await file.delete(uploadPath);
+	}
+}
+
+function validateUpload(data, maxSize, allowedTypes) {
+	if (!data.imageData) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	const size = image.sizeFromBase64(data.imageData);
+	if (size > maxSize * 1024) {
+		throw new Error(`[[error:file-too-big, ${maxSize}]]`);
+	}
+
+	const type = image.mimeFromBase64(data.imageData);
+	if (!type || !allowedTypes.includes(type)) {
+		throw new Error('[[error:invalid-image]]');
+	}
+}
+
+async function convertToPNG(path) {
+	const convertToPNG = meta.config['profile:convertProfileImageToPNG'] === 1;
+	if (!convertToPNG) {
+		return path;
+	}
+	const newPath = await image.normalise(path);
+	await file.delete(path);
+	return newPath;
+}
+
+function generateProfileImageFilename(uid, extension) {
+	const convertToPNG = meta.config['profile:convertProfileImageToPNG'] === 1;
+	return `${uid}-profileavatar-${Date.now()}${convertToPNG ? '.png' : extension}`;
+}
+
+async function getPicturePath(User, uid, field) {
+	const value = await User.getUserField(uid, field);
+	if (!value || !value.startsWith(`${nconf.get('relative_path')}/assets/uploads/profile/uid-${uid}`)) {
+		return false;
+	}
+	const filename = value.split('/').pop();
+	return path.join(nconf.get('upload_path'), `profile/uid-${uid}`, filename);
+}

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -113,10 +113,11 @@ module.exports = function (User) {
 
 	// uploads image data in base64 as profile picture
 	User.uploadCroppedPicture = async function (data) {
+		const extension = validateUploadWrapper(data);
+		const tempPath = await getProfilePathWrapper(data.imageData);
+
 		try {
 			
-			const extension = validateUploadWrapper(data);
-			const tempPath = await getProfilePathWrapper(data.imageData);
 			const uploadedImage = uploadProfilePathWrapper(data.uid, tempPath, extension);
 			await updateProfilePathWrapper(data.callerUid, data.uid, uploadedImage.url);
 			return uploadedImage;

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -24,15 +24,7 @@ module.exports = function (User) {
 		return ['image/png', 'image/jpeg', 'image/bmp', 'image/gif'];
 	};
 
-	User.updateCoverPosition = async function (uid, position) {
-		// Reject anything that isn't two percentages
-		if (!/^[\d.]+%\s[\d.]+%$/.test(position)) {
-			winston.warn(`[user/updateCoverPosition] Invalid position received: ${position}`);
-			throw new Error('[[error:invalid-data]]');
-		}
-
-		await User.setUserField(uid, 'cover:position', position);
-	};
+	User.updateCoverPosition = (uid, position) => updateCoverPositionWrapper(User, uid, position);
 
 	User.updateCoverPicture = async function (data) {
 		const picture = {
@@ -161,6 +153,15 @@ module.exports = function (User) {
 		}, ['uploadedpicture', 'picture']);
 	}
 	
+};
+
+// Wrapper for updating cover position
+function updateCoverPositionWrapper(User, uid, position) {
+	if (!/^[\d.]+%\s[\d.]+%$/.test(position)) {
+		winston.warn(`[user/updateCoverPosition] Invalid position received: ${position}`);
+		throw new Error('[[error:invalid-data]]');
+	}
+	return User.setUserField(uid, 'cover:position', position);
 };
 
 // Wrapper function which encapsulates the upload validation logic


### PR DESCRIPTION
## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue: https://github.com/CMU-313/NodeBB/issues/88**

**Full path to the refactored file: /workspaces/NodeBB/src/user**

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*

This file simply handles the uploading, updating, and deleting of a profile picture.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*

The scope I covered is pretty much the whole file. Specifically the functions that were initially defined in the module.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*

Function with high complexity (count = 21): exports

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**

Everything was defined in the module, so you couldn’t easily reuse those functions elsewhere

**What changes did you make to resolve the issue?**

To refactor I moved most of the functions defined in the module outside of it. This decluttered the module as well as made the code clearer to read.

**How do your changes improve adaptability? Did you consider alternatives?**

As mentioned before my approach enabled the reuse of functions outside the scope of the module.

## 3. Validation

**How did you trigger the refactored code path from the UI?**

To trigger the refactored code I simply changed the profile picture of a non admin account

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*

<img width="1440" height="900" alt="Screenshot 2025-09-04 at 10 21 06 PM" src="https://github.com/user-attachments/assets/0a77649e-9f3f-4bf7-966e-6d6e0f26a727" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

<img width="1440" height="900" alt="Screenshot 2025-09-04 at 11 51 55 AM" src="https://github.com/user-attachments/assets/e2aead4e-9879-4248-acaf-6bdf6776041b" />
